### PR TITLE
Replace K_FOREVER calls

### DIFF
--- a/src/mcan_fd_interrupt.c
+++ b/src/mcan_fd_interrupt.c
@@ -144,7 +144,7 @@ bool McanFdInterrupt_send(McanFdInterrupt *self, uint32_t messageId, uint8_t *me
 
     self->frame.dlc = can_bytes_to_dlc(messageLength);
 
-    uint8_t res = can_send(self->canDev, &self->frame, K_FOREVER, tx_irq_callback, self);
+    uint8_t res = can_send(self->canDev, &self->frame, K_MSEC(10), tx_irq_callback, self);
     if (res != 0) {
       return false;
     }

--- a/src/zephyr_semaphore.c
+++ b/src/zephyr_semaphore.c
@@ -5,7 +5,7 @@
 //******************************************************************************
 static bool ZephyrSemaphore_take(void *self) {
   ZephyrSemaphore *_self = (ZephyrSemaphore *)self;
-  if (k_sem_take(&_self->semaphore, K_FOREVER) == 0) { return true; }
+  if (k_sem_take(&_self->semaphore, K_MSEC(10)) == 0) { return true; }
   return false;
 }
 


### PR DESCRIPTION
* Use 10 milliseconds timeout for CAN send calls

* Use 10 milliseconds timeout for semaphore take